### PR TITLE
fix: don't log localhost errors - sentry.

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -132,6 +132,7 @@ module.exports = {
       options: {
         dsn: "https://d2e5097585b0401aab888bfa8a8570ac@o551788.ingest.sentry.io/5675666",
         sampleRate: 0.7,
+        denyUrls: ["localhost:8000"]
       },
     },
   ],


### PR DESCRIPTION
**What does this PR do?**
Removes logging for localhost in sentry.