### PR TITLE
Fixed old syntax in 03.mdx

### DIFF
--- a/lessons/tokens-FA2/03/03.mdx
+++ b/lessons/tokens-FA2/03/03.mdx
@@ -27,7 +27,7 @@ editor:
     import smartpy as sp
 
     # Import FA2 template
-    FA2 = sp.import_script_from_url("https://smartpy.io/dev/templates/FA2.py")
+    FA2 = sp.io.import_script_from_url("https://smartpy.io/dev/templates/FA2.py")
     # Define Cyber_Token
     class Cyber_Token(FA2.FA2):
         pass
@@ -38,7 +38,7 @@ editor:
         admin = sp.test_account("Decentralized Dictator")
 
         # Initialize Cyber_Token as cyber_token with single_asset = True
-        cyber_token = Cyber_Token(FA2.FA2_config(single_asset=True, assume_consecutive_token_ids = False), admin = admin.address, metadata = sp.big_map({"": sp.bytes_of_string("tezos-storage:content"),"content": sp.bytes_of_string("""{"name" : "Cyber Token"}""")}))
+        cyber_token = Cyber_Token(FA2.FA2_config(single_asset=True, assume_consecutive_token_ids = False), admin = admin.address, metadata = sp.big_map({"": sp.utils.bytes_of_string("tezos-storage:content"),"content": sp.utils.bytes_of_string("""{"name" : "Cyber Token"}""")}))
         #Add cyber_token to the scenario
         scenario += cyber_token
 ---
@@ -89,14 +89,14 @@ But what does `single_asset` mean? It signifies whether the token contract has m
 To implement a token of your own - you need to import SmartPy's FA2 template and in your own contract, rather than inheriting from `sp.Contract`, you'll inherit from the `FA2` contract.
 
 ```python
-FA2 = sp.import_script_from_url("https://smartpy.io/dev/templates/FA2.py")
+FA2 = sp.io.import_script_from_url("https://smartpy.io/dev/templates/FA2.py")
 ```
 
 This line is similar to - `import FA2` in plain python.
 But because we're writing SmartPy, the rules are different.
 You need to use -
-* `sp.import_script_from_url` - If you're not using SmartPy's online IDE.
-* `sp.import_template` - If your code is running in the SmartPy online IDE. When you use this, you would be required to just pass in `"FA2.py"` as the argument and not the whole URL.
+* `sp.io.import_script_from_url` - If you're not using SmartPy's online IDE.
+* `sp.io.import_template` - If your code is running in the SmartPy online IDE. When you use this, you would be required to just pass in `"FA2.py"` as the argument and not the whole URL.
 
 <br />
 
@@ -105,7 +105,7 @@ There are a lot of classes in the FA2 template along with the core `FA2` contrac
 To access the `FA2` contract defined in the template, you need to use the dot(.) notation - `FA2.FA2`, where the first `FA2` represents the template as a whole and the second `FA2` represents the actual contract class defined in the template.
 
 ```python
-FA2 = sp.import_script_from_url("https://smartpy.io/dev/templates/FA2.py")
+FA2 = sp.io.import_script_from_url("https://smartpy.io/dev/templates/FA2.py")
 class Your_Token(FA2.FA2):
     pass
 
@@ -116,7 +116,7 @@ def test():
     admin = sp.test_account("Elon Musk owns this account.")
 
     your_token = Your_Token(FA2.FA2_config(single_asset = True), admin = admin.address,
-    metadata = sp.big_map({"": sp.bytes_of_string("tezos-storage:content"),"content": sp.bytes_of_string("""{"name" : "Your Token"}""")}))
+    metadata = sp.big_map({"": sp.utils.bytes_of_string("tezos-storage:content"),"content": sp.utils.bytes_of_string("""{"name" : "Your Token"}""")}))
 ```
 
 That's all the code needed to implement your own fungible token!
@@ -125,7 +125,7 @@ Look at the last line of code in the snippet above -
 
 ```python
 your_token = Your_Token(FA2.FA2_config(single_asset = True), admin.address,
-metadata = sp.big_map({"": sp.bytes_of_string("tezos-storage:content"),"content": sp.bytes_of_string("""{"name" : "Your Token"}""")}))
+metadata = sp.big_map({"": sp.utils.bytes_of_string("tezos-storage:content"),"content": sp.utils.bytes_of_string("""{"name" : "Your Token"}""")}))
 ```
 
 On first look, we're initializing a smart contract like we usually do.
@@ -138,7 +138,7 @@ Let's deconstruct it!
 
 
 ```python
-metadata = sp.big_map({"": sp.bytes_of_string("tezos-storage:content"),"content": sp.bytes_of_string("""{"name" : "Your Token"}""")}))
+metadata = sp.big_map({"": sp.utils.bytes_of_string("tezos-storage:content"),"content": sp.utils.bytes_of_string("""{"name" : "Your Token"}""")}))
 ```
 
 <br />
@@ -158,5 +158,5 @@ Take the first steps towards building the universe's most advanced civilization,
 
 1. Import the FA2 template using and set it equal to `FA2`.
 2. Define a smart contract - `Cyber_Token` that inherits from the core FA2 contract. (Use `Your_Token`) in the example above as a reference.
-3. Initialize `Cyber_Token` with `single_asset=True`, `assume_consecutive_tokens=False`, address to the `admin`, and in the `metadata`, `name` needs to be equal to `"Cyber Token"`.
+3. Initialize `Cyber_Token` with `single_asset=True`, `assume_consecutive_token_ids=False`, address to the `admin`, and in the `metadata`, `name` needs to be equal to `"Cyber Token"`.
 4. Add `cyber_token` to the scenario.


### PR DESCRIPTION
Updated syntax change:
sp.import_script_from_url -> sp.io.import_script_from_url
sp.import_template -> sp.io.import_template
sp.bytes_of_string -> sp.utils.bytes_of_string

Fixed typo:
assume_consecutive_tokens -> assume_consecutive_token_ids

Please refer to issue #358 